### PR TITLE
Add `countdown` option to iOSMode types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 import { FC, Ref, SyntheticEvent } from 'react'
 import { NativeComponent, ViewProps } from 'react-native'
 
-type IOSMode = 'date' | 'time' | 'datetime';
+type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
 type AndroidMode = 'date' | 'time';
 type Display = 'spinner' | 'default' | 'clock' | 'calendar';
 

--- a/src/types.js
+++ b/src/types.js
@@ -8,7 +8,7 @@ import type {NativeComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
 import type {ElementRef} from 'react';
 
-type IOSMode = 'date' | 'time' | 'datetime';
+type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
 type AndroidMode = 'date' | 'time';
 type Display = 'spinner' | 'default' | 'clock' | 'calendar';
 


### PR DESCRIPTION
# Summary
The `countdown` mode is a valid iOS mode, but the string is not recognized as a valid option by Typescript, and should be added to the type.

To avoid throwing an error, I currently need to use something like `mode={'countdown' as any}`. This is not the intended flow.

Fixes #28 

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
