### PR TITLE
add (back?) Install using react-native link section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ or
 yarn add @react-native-community/datetimepicker
 ```
 
+### Install using react-native link
+```bash
+react-native link @react-native-community/datetimepicker
+```
+
+Don't forget to run `pod install` in ios and to sync Gradle in android project.
 ### Manual installation
 
 #### iOS

--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ or
 yarn add @react-native-community/datetimepicker
 ```
 
-If you are using RN > 0.60 then you are done, as the linking is automatic, but don't forget to run `pod install` from the ios directory. Then rebuild your project.
+If you are using RN > 0.60, only run `pod install` from the ios directory. Then rebuild your project.
 
-For RN < 0.60, use `react-native link`:
+For RN < 0.60, you need to link the dependency using `react-native link`:
 
 ```bash
 react-native link @react-native-community/datetimepicker
 ```
 
-Don't forget to run `pod install` from the ios directory. Then rebuild your project.
+Then run `pod install` from the ios directory and rebuild your project.
 
 ### Manual installation
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ or
 yarn add @react-native-community/datetimepicker
 ```
 
+If you are using RN > 0.60 then you are done as the linking is automatic, but don't forget to run `pod install`.
+
 ### Install using react-native link
 ```bash
 react-native link @react-native-community/datetimepicker

--- a/README.md
+++ b/README.md
@@ -65,14 +65,16 @@ or
 yarn add @react-native-community/datetimepicker
 ```
 
-If you are using RN > 0.60 then you are done as the linking is automatic, but don't forget to run `pod install`.
+If you are using RN > 0.60 then you are done, as the linking is automatic, but don't forget to run `pod install` from the ios directory. Then rebuild your project.
 
-### Install using react-native link
+For RN < 0.60, use `react-native link`:
+
 ```bash
 react-native link @react-native-community/datetimepicker
 ```
 
-Don't forget to run `pod install` in ios and to sync Gradle in android project.
+Don't forget to run `pod install` from the ios directory. Then rebuild your project.
+
 ### Manual installation
 
 #### iOS


### PR DESCRIPTION
# Summary
I was struggling with installing the lib manually, so I've tried this method. Only after that I've noticed that there's a missing documentation link here, so I decided to add it.