### PR TITLE
Fix Android Nougat datetime picker mode="spinner"

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -7,12 +7,7 @@
 
 package com.reactcommunity.rndatetimepicker;
 
-import javax.annotation.Nullable;
-
-import java.util.Calendar;
-import java.util.Locale;
 import android.annotation.SuppressLint;
-
 import android.app.DatePickerDialog;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.app.Dialog;
@@ -21,8 +16,12 @@ import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
 import android.os.Build;
 import android.os.Bundle;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import android.widget.DatePicker;
+
+import java.util.Calendar;
+import java.util.Locale;
 
 @SuppressLint("ValidFragment")
 public class RNDatePickerDialogFragment extends DialogFragment {

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
@@ -11,16 +11,15 @@ import android.app.DatePickerDialog.OnDateSetListener;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
 import android.os.Bundle;
+import android.widget.DatePicker;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
-import android.widget.DatePicker;
 
 import com.facebook.react.bridge.*;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
@@ -37,7 +36,7 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
   }
 
   @Override
-  public @Nonnull String getName() {
+  public @NonNull String getName() {
     return RNDatePickerDialogModule.FRAGMENT_TAG;
   }
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableDatePickerDialog.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableDatePickerDialog.java
@@ -8,11 +8,16 @@
 package com.reactcommunity.rndatetimepicker;
 
 import android.app.DatePickerDialog;
-import javax.annotation.Nullable;
-
 import android.app.DatePickerDialog;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.os.Build;
+import android.util.AttributeSet;
+import android.widget.DatePicker;
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 /**
  * <p>
@@ -33,6 +38,7 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
       int monthOfYear,
       int dayOfMonth) {
     super(context, callback, year, monthOfYear, dayOfMonth);
+    fixSpinner(context, year, monthOfYear, dayOfMonth);
   }
 
   public RNDismissableDatePickerDialog(
@@ -43,6 +49,7 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
       int monthOfYear,
       int dayOfMonth) {
     super(context, theme, callback, year, monthOfYear, dayOfMonth);
+    fixSpinner(context, year, monthOfYear, dayOfMonth);
   }
 
   @Override
@@ -52,5 +59,80 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
       super.onStop();
     }
+  }
+
+  private void fixSpinner(Context context, int year, int month, int dayOfMonth) {
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
+      try {
+        // Get the theme's android:datePickerMode
+        final int MODE_SPINNER = 2;
+        Class<?> styleableClass = Class.forName("com.android.internal.R$styleable");
+        Field datePickerStyleableField = styleableClass.getField("DatePicker");
+        int[] datePickerStyleable = (int[]) datePickerStyleableField.get(null);
+
+        final TypedArray a =
+            context.obtainStyledAttributes(
+                null, datePickerStyleable, android.R.attr.datePickerStyle, 0);
+        Field datePickerModeStyleableField = styleableClass.getField("DatePicker_datePickerMode");
+        int datePickerModeStyleable = datePickerModeStyleableField.getInt(null);
+        final int mode = a.getInt(datePickerModeStyleable, MODE_SPINNER);
+        a.recycle();
+
+        if (mode == MODE_SPINNER) {
+          DatePicker datePicker =
+              (DatePicker)
+                  findField(DatePickerDialog.class, DatePicker.class, "mDatePicker").get(this);
+          Class<?> delegateClass = Class.forName("android.widget.DatePickerSpinnerDelegate");
+          Field delegateField = findField(DatePicker.class, delegateClass, "mDelegate");
+          Object delegate = delegateField.get(datePicker);
+          Class<?> spinnerDelegateClass;
+          spinnerDelegateClass = Class.forName("android.widget.DatePickerSpinnerDelegate");
+
+          // In 7.0 Nougat for some reason the datePickerMode is ignored and the delegate is
+          // DatePickerClockDelegate
+          if (delegate.getClass() != spinnerDelegateClass) {
+            delegateField.set(datePicker, null); // throw out the DatePickerClockDelegate!
+            datePicker.removeAllViews(); // remove the DatePickerClockDelegate views
+            Method createSpinnerUIDelegate =
+                DatePicker.class.getDeclaredMethod(
+                    "createSpinnerUIDelegate",
+                    Context.class,
+                    AttributeSet.class,
+                    int.class,
+                    int.class);
+            createSpinnerUIDelegate.setAccessible(true);
+
+            // Instantiate a DatePickerSpinnerDelegate throughout createSpinnerUIDelegate method
+            delegate =
+                createSpinnerUIDelegate.invoke(
+                    datePicker, context, null, android.R.attr.datePickerStyle, 0);
+            delegateField.set(
+                datePicker, delegate); // set the DatePicker.mDelegate to the spinner delegate
+            datePicker.setCalendarViewShown(false);
+            // Initialize the date for the DatePicker delegate again
+            datePicker.init(year, month, dayOfMonth, this);
+          }
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private static Field findField(Class objectClass, Class fieldClass, String expectedName) {
+    try {
+      Field field = objectClass.getDeclaredField(expectedName);
+      field.setAccessible(true);
+      return field;
+    } catch (NoSuchFieldException e) {
+    } // ignore
+    // search for it if it wasn't found under the expected ivar name
+    for (Field searchField : objectClass.getDeclaredFields()) {
+      if (searchField.getType() == fieldClass) {
+        searchField.setAccessible(true);
+        return searchField;
+      }
+    }
+    return null;
   }
 }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableTimePickerDialog.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableTimePickerDialog.java
@@ -7,11 +7,16 @@
 package com.reactcommunity.rndatetimepicker;
 
 import android.app.TimePickerDialog;
-import javax.annotation.Nullable;
-
 import android.app.TimePickerDialog;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.os.Build;
+import android.util.AttributeSet;
+import android.widget.TimePicker;
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 
 /**
  * <p>
@@ -34,6 +39,7 @@ public class RNDismissableTimePickerDialog extends TimePickerDialog {
       int minute,
       boolean is24HourView) {
     super(context, callback, hourOfDay, minute, is24HourView);
+    fixSpinner(context, hourOfDay, minute, is24HourView);
   }
 
   public RNDismissableTimePickerDialog(
@@ -44,6 +50,7 @@ public class RNDismissableTimePickerDialog extends TimePickerDialog {
       int minute,
       boolean is24HourView) {
     super(context, theme, callback, hourOfDay, minute, is24HourView);
+    fixSpinner(context, hourOfDay, minute, is24HourView);
   }
 
   @Override
@@ -53,4 +60,62 @@ public class RNDismissableTimePickerDialog extends TimePickerDialog {
     }
   }
 
+  private void fixSpinner(Context context, int hourOfDay, int minute, boolean is24HourView) {
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
+      try {
+        // Get the theme's android:timePickerMode
+        final int MODE_SPINNER = 1;
+        Class<?> styleableClass = Class.forName("com.android.internal.R$styleable");
+        Field timePickerStyleableField = styleableClass.getField("TimePicker");
+        int[] timePickerStyleable = (int[]) timePickerStyleableField.get(null);
+        final TypedArray a = context.obtainStyledAttributes(null, timePickerStyleable, android.R.attr.timePickerStyle, 0);
+        Field timePickerModeStyleableField = styleableClass.getField("TimePicker_timePickerMode");
+        int timePickerModeStyleable = timePickerModeStyleableField.getInt(null);
+        final int mode = a.getInt(timePickerModeStyleable, MODE_SPINNER);
+        a.recycle();
+        if (mode == MODE_SPINNER) {
+          TimePicker timePicker = (TimePicker) findField(TimePickerDialog.class, TimePicker.class, "mTimePicker").get(this);
+          Class<?> delegateClass = Class.forName("android.widget.TimePicker$TimePickerDelegate");
+          Field delegateField = findField(TimePicker.class, delegateClass, "mDelegate");
+          Object delegate = delegateField.get(timePicker);
+          Class<?> spinnerDelegateClass;
+          spinnerDelegateClass = Class.forName("android.widget.TimePickerSpinnerDelegate");
+          // In 7.0 Nougat for some reason the timePickerMode is ignored and the delegate is TimePickerClockDelegate
+          if (delegate.getClass() != spinnerDelegateClass) {
+            delegateField.set(timePicker, null); // throw out the TimePickerClockDelegate!
+            timePicker.removeAllViews(); // remove the TimePickerClockDelegate views
+            Constructor spinnerDelegateConstructor = spinnerDelegateClass.getConstructor(TimePicker.class, Context.class, AttributeSet.class, int.class, int.class);
+            spinnerDelegateConstructor.setAccessible(true);
+            // Instantiate a TimePickerSpinnerDelegate
+            delegate = spinnerDelegateConstructor.newInstance(timePicker, context, null, android.R.attr.timePickerStyle, 0);
+            delegateField.set(timePicker, delegate); // set the TimePicker.mDelegate to the spinner delegate
+            // Set up the TimePicker again, with the TimePickerSpinnerDelegate
+            timePicker.setIs24HourView(is24HourView);
+            timePicker.setCurrentHour(hourOfDay);
+            timePicker.setCurrentMinute(minute);
+            timePicker.setOnTimeChangedListener(this);
+          }
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private static Field findField(Class objectClass, Class fieldClass, String expectedName) {
+    try {
+      Field field = objectClass.getDeclaredField(expectedName);
+      field.setAccessible(true);
+      return field;
+    } catch (NoSuchFieldException e) {
+    } // ignore
+    // search for it if it wasn't found under the expected ivar name
+    for (Field searchField : objectClass.getDeclaredFields()) {
+      if (searchField.getType() == fieldClass) {
+        searchField.setAccessible(true);
+        return searchField;
+      }
+    }
+    return null;
+  }
 }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
@@ -15,13 +15,12 @@ import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
 import android.os.Build;
 import android.os.Bundle;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import android.text.format.DateFormat;
 
 import java.util.Calendar;
 import java.util.Locale;
-
-import javax.annotation.Nullable;
 
 @SuppressWarnings("ValidFragment")
 public class RNTimePickerDialogFragment extends DialogFragment {

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
@@ -7,20 +7,19 @@
 
 package com.reactcommunity.rndatetimepicker;
 
-import android.app.TimePickerDialog.OnTimeSetListener;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnDismissListener;
-import android.os.Bundle;
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.fragment.app.FragmentManager;
-import android.widget.TimePicker;
-
 import com.facebook.react.bridge.*;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
 
-import javax.annotation.Nullable;
+import android.app.TimePickerDialog.OnTimeSetListener;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
+import android.os.Bundle;
+import android.widget.TimePicker;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 
 /**
  * {@link NativeModule} that allows JS to show a native time picker dialog and get called back when


### PR DESCRIPTION
# Summary

I got it from https://gist.github.com/jeffdgr8/6bc5f990bf0c13a7334ce385d482af9f and
did some adjustments in order to work with DatePicker. Workaround for this bug: https://code.google.com/p/android/issues/detail?id=222208. In Android 7.0 Nougat, spinner mode for the DatePicker in DatePickerDialog is incorrectly displayed as calendar.

## Test Plan

Run Example with Android Emulator with Android Nougat (7.0), and modify example setting `mode="spinner"`

### What are the steps to reproduce (after prerequisites)?

Run Example in current `master branch` with Android Emulator with Android Nougat (7.0), and modify example setting `mode="spinner"` the emulator shows calendar

## Checklist

- [X] I have tested this on a device and a simulator
