### PR TITLE
Support compiling with other platforms

### DIFF
--- a/src/datetimepicker.js
+++ b/src/datetimepicker.js
@@ -1,0 +1,1 @@
+export default undefined;

--- a/src/datetimepicker.js
+++ b/src/datetimepicker.js
@@ -1,3 +1,6 @@
+import React from 'react';
+import { Platform } from 'react-native';
+
 export default function DateTimePicker() {
   React.useEffect(() => {
     console.warn(`DateTimePicker is not supported on: ${Platform.OS}`);

--- a/src/datetimepicker.js
+++ b/src/datetimepicker.js
@@ -1,1 +1,6 @@
-export default undefined;
+export default function DateTimePicker() {
+  React.useEffect(() => {
+    console.warn(`DateTimePicker is not supported on: ${Platform.OS}`);
+  }, [])
+  return null;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
 import RNDateTimePicker from './datetimepicker';
 
 export default RNDateTimePicker;
-


### PR DESCRIPTION
# Summary
When using this plugin in a project which targets an environment other than Android or iOS it can't be compiled because the file `datetimepicker` has no default entry.

## Test Plan
```
npm install --save git+https://github.com/aikewoody/react-native-datetimepicker.git#feature-support-all-platforms
# Install react-native-web
# If you're inside an Expo project: https://docs.expo.io/versions/v33.0.0/introduction/running-in-the-browser/
expo install react-native-web react-dom
expo start --web
```

### What's required for testing (prerequisites)?
An Expo project with the `react-native-community/react-native-datetimepicker` plugin installed.

### What are the steps to reproduce (after prerequisites)?
```
npm install --save @react-native-community/datetimepicker@latest
# Install react-native-web
# If you're inside an Expo project: https://docs.expo.io/versions/v33.0.0/introduction/running-in-the-browser/
expo install react-native-web react-dom
expo start --web
```

The following error appears:
```
web  Failed to compile.
/Users/.../node_modules/@react-native-community/datetimepicker/src/index.js
Module not found: Can't resolve './datetimepicker' in '/Users/.../node_modules/@react-native-community/datetimepicker/src'
```

## Compatibility
| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web |    ✅     |
| macOS |    ✅     |
| Windows |    ✅     |

## Checklist
- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
