### PR TITLE
Missing TypeScript Type: 'countdown'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ React Native date & time picker component for iOS and Android
       - [iOS](#ios)
       - [Android](#android)
   - [Getting started](#getting-started)
-    - [Install using react-native link](#install-using-react-native-link)
     - [Manual installation](#manual-installation)
       - [iOS](#ios-1)
       - [Android](#android-1)
@@ -147,21 +146,21 @@ yarn add @react-native-community/datetimepicker
 ## General Usage
 
 ```js
-import DateTimePicker from '@react-native-community/datetimepicker';
+import RNDateTimePicker from '@react-native-community/datetimepicker';
 ```
 
 or
 
 ```js
-const DateTimePicker = require('@react-native-community/datetimepicker');
+const RNDateTimePicker = require('@react-native-community/datetimepicker');
 ```
 
 ### Basic usage with state
 
 ```js
-import React, {Component} from 'react';
-import {View, Button, Platform} from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import React, { Component } from 'react';
+import { View, Button, Platform } from 'react-native';
+import RNDateTimePicker from '@react-native-community/datetimepicker';
 
 export default class App extends Component {
   state = {
@@ -205,7 +204,7 @@ export default class App extends Component {
         <View>
           <Button onPress={this.timepicker} title="Show time picker!" />
         </View>
-        { show && <DateTimePicker value={date}
+        { show && <RNDateTimePicker value={date}
                     mode={mode}
                     is24Hour={true}
                     display="default"
@@ -384,7 +383,7 @@ On Android, open picker modals will update the selected date and/or time if the 
     ```js
     // Before
     try {
-      const {action, year, month, day} = await DatePickerAndroid.open({
+      const { action, year, month, day } = await DatePickerAndroid.open({
         date: new Date()
       });
     } catch ({code, message}) {
@@ -402,7 +401,7 @@ On Android, open picker modals will update the selected date and/or time if the 
     ```js
     // Before
     try {
-      const {action, year, month, day} = await DatePickerAndroid.open({
+      const { action, year, month, day } = await DatePickerAndroid.open({
         minDate: new Date(),
         maxDate: new Date()
       });

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ React Native date & time picker component for iOS and Android
       - [iOS](#ios)
       - [Android](#android)
   - [Getting started](#getting-started)
+    - [Install using react-native link](#install-using-react-native-link)
     - [Manual installation](#manual-installation)
       - [iOS](#ios-1)
       - [Android](#android-1)
@@ -146,21 +147,21 @@ yarn add @react-native-community/datetimepicker
 ## General Usage
 
 ```js
-import RNDateTimePicker from '@react-native-community/datetimepicker';
+import DateTimePicker from '@react-native-community/datetimepicker';
 ```
 
 or
 
 ```js
-const RNDateTimePicker = require('@react-native-community/datetimepicker');
+const DateTimePicker = require('@react-native-community/datetimepicker');
 ```
 
 ### Basic usage with state
 
 ```js
-import React, { Component } from 'react';
-import { View, Button, Platform } from 'react-native';
-import RNDateTimePicker from '@react-native-community/datetimepicker';
+import React, {Component} from 'react';
+import {View, Button, Platform} from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
 
 export default class App extends Component {
   state = {
@@ -204,7 +205,7 @@ export default class App extends Component {
         <View>
           <Button onPress={this.timepicker} title="Show time picker!" />
         </View>
-        { show && <RNDateTimePicker value={date}
+        { show && <DateTimePicker value={date}
                     mode={mode}
                     is24Hour={true}
                     display="default"
@@ -383,7 +384,7 @@ On Android, open picker modals will update the selected date and/or time if the 
     ```js
     // Before
     try {
-      const { action, year, month, day } = await DatePickerAndroid.open({
+      const {action, year, month, day} = await DatePickerAndroid.open({
         date: new Date()
       });
     } catch ({code, message}) {
@@ -401,7 +402,7 @@ On Android, open picker modals will update the selected date and/or time if the 
     ```js
     // Before
     try {
-      const { action, year, month, day } = await DatePickerAndroid.open({
+      const {action, year, month, day} = await DatePickerAndroid.open({
         minDate: new Date(),
         maxDate: new Date()
       });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 import { FC, Ref, SyntheticEvent } from 'react'
 import { NativeComponent, ViewProps } from 'react-native'
 
-type IOSMode = 'date' | 'time' | 'datetime';
+type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
 type AndroidMode = 'date' | 'time';
 type Display = 'spinner' | 'default' | 'clock' | 'calendar';
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 import { FC, Ref, SyntheticEvent } from 'react'
 import { NativeComponent, ViewProps } from 'react-native'
 
-type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
+type IOSMode = 'date' | 'time' | 'datetime';
 type AndroidMode = 'date' | 'time';
 type Display = 'spinner' | 'default' | 'clock' | 'calendar';
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

IOSPicker is missing the "countdown" TypeScript type [located here in the docs](https://github.com/react-native-community/react-native-datetimepicker#mode-optional)


<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
