### PR TITLE
Fix android time picker returning today's date instead of the given date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 2.2.2
+- Fix android time picker returning today's date instead of the given date
+
 ### 2.2.0
 
 - Fix podspec to get source from tag [#103](https://github.com/react-native-community/react-native-datetimepicker/pull/103)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-### 2.2.2
+### 2.2.1
 - Fix android time picker returning today's date instead of the given date
 
 ### 2.2.0

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -54,7 +54,7 @@ export default function RNDateTimePicker({
 
   picker.then(
     function resolve({action, day, month, year, minute, hour}) {
-      const date = new Date();
+      const date = new Date(value);
       const event: AndroidEvent = {
         type: 'set',
         nativeEvent: {},


### PR DESCRIPTION
# Summary

After a time value is chosen in the android picker, use the value prop to create the date object so it doesn't default to returning the current date when using the time picker. Closes #94

## Test Plan

### What's required for testing (prerequisites)?

A test project for android with a time picker set to ```mode="time"```

### What are the steps to reproduce (after prerequisites)?

Pass the time picker a date that is not today, log the value returned from the picker after selecting a time, and see that it returns today's date.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md` - not applicable for bug fix
- [x] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow) - not applicable for bug fix
- [ ] I added a sample use of the API in the example project (`example/App.js`) - not applicable for bug fix
