### PR TITLE
Add styling prop for iOS picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Sets style directly on picker component within internal container.
 By default height of picker is fixed to 216px regardless of what is set in style property.
 
 ```js
-<RNDateTimePicker iOsPickerStyle={{flex: 1}} /> // will take up whole space defined in style property
+<RNDateTimePicker iOsPickerStyle={{width: '100%', height: '100% '}} /> // will take up whole space defined in style property
 ```
 
 ## Migration from the older components

--- a/README.md
+++ b/README.md
@@ -23,29 +23,34 @@ React Native date & time picker component for iOS and Android
 ## Table of Contents
 
 - [React Native DateTimePicker](#react-native-datetimepicker)
+  - [Table of Contents](#table-of-contents)
   - [Getting started](#getting-started)
+      - [RN >= 0.60](#rn--060)
+      - [RN < 0.60](#rn--060-1)
   - [General Usage](#general-usage)
     - [Basic usage with state](#basic-usage-with-state)
   - [Props](#props)
-    - [`mode` (`optional`)](#mode-optional)
-    - [`display` (`optional`, `Android only`)](#display-optional-android-only)
-    - [`onChange` (`optional`)](#onchange-optional)
-    - [`value` (`required`)](#value-required)
-    - [`maximumDate` (`optional`)](#maximumdate-optional)
-    - [`minimumDate` (`optional`)](#minimumdate-optional)
-    - [`timeZoneOffsetInMinutes` (`optional`, `iOS only`)](#timezoneoffsetinminutes-optional-ios-only)
-    - [`locale` (`optional`, `iOS only`)](#locale-optional-ios-only)
-    - [`is24Hour` (`optional`, `Android only`)](#is24hour-optional-android-only)
-    - [`neutralButtonLabel` (`optional`, `Android only`)](#neutralbuttonlabel-optional-android-only)
-    - [`minuteInterval` (`optional`, `iOS only`)](#minuteinterval-optional-ios-only)
+      - [`mode` (`optional`)](#mode-optional)
+      - [`display` (`optional`, `Android only`)](#display-optional-android-only)
+      - [`onChange` (`optional`)](#onchange-optional)
+      - [`value` (`required`)](#value-required)
+      - [`maximumDate` (`optional`)](#maximumdate-optional)
+      - [`minimumDate` (`optional`)](#minimumdate-optional)
+      - [`timeZoneOffsetInMinutes` (`optional`, `iOS only`)](#timezoneoffsetinminutes-optional-ios-only)
+      - [`locale` (`optional`, `iOS only`)](#locale-optional-ios-only)
+      - [`is24Hour` (`optional`, `Android only`)](#is24hour-optional-android-only)
+      - [`neutralButtonLabel` (`optional`, `Android only`)](#neutralbuttonlabel-optional-android-only)
+      - [`minuteInterval` (`optional`, `iOS only`)](#minuteinterval-optional-ios-only)
+      - [`iOsPickerStyle` (`optional`, `iOS only`)](#iospickerstyle-optional-ios-only)
   - [Migration from the older components](#migration-from-the-older-components)
     - [DatePickerIOS](#datepickerios)
     - [DatePickerAndroid](#datepickerandroid)
     - [TimePickerAndroid](#timepickerandroid)
   - [Contributing to the component](#contributing-to-the-component)
   - [Manual installation](#manual-installation)
+      - [iOS](#ios)
+      - [Android](#android)
   - [Running the example app](#running-the-example-app)
-
 
 ## Getting started
 
@@ -147,8 +152,8 @@ export default App;
 
 ## Props
 
-> Please note that this library currently exposes functionality from [`UIDatePicker`](https://developer.apple.com/documentation/uikit/uidatepicker?language=objc) on iOS and [DatePickerDialog](https://developer.android.com/reference/android/app/DatePickerDialog) + [TimePickerDialog](https://developer.android.com/reference/android/app/TimePickerDialog) on Android. 
-> 
+> Please note that this library currently exposes functionality from [`UIDatePicker`](https://developer.apple.com/documentation/uikit/uidatepicker?language=objc) on iOS and [DatePickerDialog](https://developer.android.com/reference/android/app/DatePickerDialog) + [TimePickerDialog](https://developer.android.com/reference/android/app/TimePickerDialog) on Android.
+>
 > These native classes offer only limited configuration, while there are dozens of possible options you as a developer may need. It follows that if your requirement is not supported by the backing native views, this libray will _not_ be able to implement your requirement. When you open an issue with a feature request, please document if (or how) the feature can be implemented using the aforementioned native views. If those views do not support what you need, such feature requests will be closed as not actionable.
 
 #### `mode` (`optional`)
@@ -156,6 +161,7 @@ export default App;
 Defines the type of the picker.
 
 List of possible values:
+
 - `"date"` (default for `iOS` and `Android`)
 - `"time"`
 - `"datetime"` (`iOS` only)
@@ -170,6 +176,7 @@ List of possible values:
 Defines the visual display of the picker for Android and will be ignored for iOS.
 
 List of possible values:
+
 - `"default"`
 - `"spinner"`
 - `"calendar"` (only for `date` mode)
@@ -186,9 +193,9 @@ Date change handler.
 This is called when the user changes the date or time in the UI. It receives the event and the date as parameters.
 
 ```js
-setDate = (event, date) => {}
+setDate = (event, date) => {};
 
-<RNDateTimePicker onChange={this.setDate} />
+<RNDateTimePicker onChange={this.setDate} />;
 ```
 
 #### `value` (`required`)
@@ -258,6 +265,15 @@ Possible values are: `1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30`
 <RNDateTimePicker minuteInterval={10} />
 ```
 
+#### `iOsPickerStyle` (`optional`, `iOS only`)
+
+Sets style directly on picker component within internal container.
+By default height of picker is fixed to 216px regardless of what is set in style property.
+
+```js
+<RNDateTimePicker iOsPickerStyle={{flex: 1}} /> // will take up whole space defined in style property
+```
+
 ## Migration from the older components
 
 `RNDateTimePicker` is the new common name used to represent the old versions of iOS and Android.
@@ -266,218 +282,222 @@ On Android, open picker modals will update the selected date and/or time if the 
 
 ### DatePickerIOS
 
--  `initialDate` is deprecated, use `value` instead.
+- `initialDate` is deprecated, use `value` instead.
 
-    ```js
-    // Before
-    <DatePickerIOS initialValue={new Date()} />
-    ```
+  ```js
+  // Before
+  <DatePickerIOS initialValue={new Date()} />
+  ```
 
-    ```js
-    // Now
-    <RNDateTimePicker value={new Date()} />
-    ```
+  ```js
+  // Now
+  <RNDateTimePicker value={new Date()} />
+  ```
 
 - `date` is deprecated, use `value` instead.
 
-    ```js
-    // Before
-    <DatePickerIOS date={new Date()} />
-    ```
+  ```js
+  // Before
+  <DatePickerIOS date={new Date()} />
+  ```
 
-    ```js
-    // Now
-    <RNDateTimePicker value={new Date()} />
-    ```
+  ```js
+  // Now
+  <RNDateTimePicker value={new Date()} />
+  ```
 
 - `onChange` now returns also the date.
 
-    ```js
-    // Before
-    onChange = (event) => {}
-    <DatePickerIOS onChange={this.onChange} />
-    ```
+  ```js
+  // Before
+  onChange = event => {};
+  <DatePickerIOS onChange={this.onChange} />;
+  ```
 
-    ```js
-    // Now
-    onChange = (event, date) => {}
-    <RNDateTimePicker onChange={this.onChange} />
-    ```
+  ```js
+  // Now
+  onChange = (event, date) => {};
+  <RNDateTimePicker onChange={this.onChange} />;
+  ```
 
 - `onDateChange` is deprecated, use `onChange` instead.
 
-    ```js
-    // Before
-    setDate = (date) => {}
-    <DatePickerIOS onDateChange={this.setDate} />
-    ```
+  ```js
+  // Before
+  setDate = date => {};
+  <DatePickerIOS onDateChange={this.setDate} />;
+  ```
 
-    ```js
-    // Now
-    setDate = (event, date) => {}
-    <RNDateTimePicker onChange={this.setDate} />
-    ```
+  ```js
+  // Now
+  setDate = (event, date) => {};
+  <RNDateTimePicker onChange={this.setDate} />;
+  ```
 
 ### DatePickerAndroid
 
 - `date` is deprecated, use `value` instead.
 
-    ```js
-    // Before
-    try {
-      const {action, year, month, day} = await DatePickerAndroid.open({
-        date: new Date()
-      });
-    } catch ({code, message}) {
-      console.warn('Cannot open date picker', message);
-    }
-    ```
+  ```js
+  // Before
+  try {
+    const {action, year, month, day} = await DatePickerAndroid.open({
+      date: new Date(),
+    });
+  } catch ({code, message}) {
+    console.warn('Cannot open date picker', message);
+  }
+  ```
 
-    ```js
-    // Now
-    <RNDateTimePicker mode="date" value={new Date()} />
-    ```
+  ```js
+  // Now
+  <RNDateTimePicker mode="date" value={new Date()} />
+  ```
 
 - `minDate` and `maxDate` are deprecated, use `minimumDate` and `maximumDate` instead.
 
-    ```js
-    // Before
-    try {
-      const {action, year, month, day} = await DatePickerAndroid.open({
-        minDate: new Date(),
-        maxDate: new Date()
-      });
-    } catch ({code, message}) {
-      console.warn('Cannot open date picker', message);
-    }
-    ```
+  ```js
+  // Before
+  try {
+    const {action, year, month, day} = await DatePickerAndroid.open({
+      minDate: new Date(),
+      maxDate: new Date(),
+    });
+  } catch ({code, message}) {
+    console.warn('Cannot open date picker', message);
+  }
+  ```
 
-    ```js
-    // Now
-    <RNDateTimePicker mode="date" minimumDate={new Date()} maximumDate={new Date()} />
-    ```
+  ```js
+  // Now
+  <RNDateTimePicker
+    mode="date"
+    minimumDate={new Date()}
+    maximumDate={new Date()}
+  />
+  ```
 
 - `dateSetAction` is deprecated, use `onChange` instead.
 
-    ```js
-    // Before
-    try {
-      const {action, year, month, day} = await DatePickerAndroid.open();
-      if (action === DatePickerAndroid.dateSetAction) {
-        // Selected year, month (0-11), day
-      }
-    } catch ({code, message}) {
-      console.warn('Cannot open date picker', message);
+  ```js
+  // Before
+  try {
+    const {action, year, month, day} = await DatePickerAndroid.open();
+    if (action === DatePickerAndroid.dateSetAction) {
+      // Selected year, month (0-11), day
     }
-    ```
+  } catch ({code, message}) {
+    console.warn('Cannot open date picker', message);
+  }
+  ```
 
-    ```js
-    // Now
-    setDate = (event, date) => {
-      if (date !== undefined) {
-        // timeSetAction
-      }
+  ```js
+  // Now
+  setDate = (event, date) => {
+    if (date !== undefined) {
+      // timeSetAction
     }
-    <RNDateTimePicker mode="date" onChange={this.setDate} />
-    ```
+  };
+  <RNDateTimePicker mode="date" onChange={this.setDate} />;
+  ```
 
 - `dismissedAction` is deprecated, use `onChange` instead.
 
-    ```js
-    // Before
-    try {
-      const {action, year, month, day} = await DatePickerAndroid.open();
-      if (action === DatePickerAndroid.dismissedAction) {
-        // Dismissed
-      }
-    } catch ({code, message}) {
-      console.warn('Cannot open date picker', message);
+  ```js
+  // Before
+  try {
+    const {action, year, month, day} = await DatePickerAndroid.open();
+    if (action === DatePickerAndroid.dismissedAction) {
+      // Dismissed
     }
-    ```
+  } catch ({code, message}) {
+    console.warn('Cannot open date picker', message);
+  }
+  ```
 
-    ```js
-    // Now
-    setDate = (event, date) => {
-      if (date === undefined) {
-        // dismissedAction
-      }
+  ```js
+  // Now
+  setDate = (event, date) => {
+    if (date === undefined) {
+      // dismissedAction
     }
-    <RNDateTimePicker mode="date" onChange={this.setDate} />
-    ```
+  };
+  <RNDateTimePicker mode="date" onChange={this.setDate} />;
+  ```
 
 ### TimePickerAndroid
 
 - `hour` and `minute` are deprecated, use `value` instead.
 
-    ```js
-    // Before
-    try {
-      const {action, hour, minute} = await TimePickerAndroid.open({
-        hour: 14,
-        minute: 0,
-        is24Hour: false, // Will display '2 PM'
-      });
-      if (action !== TimePickerAndroid.dismissedAction) {
-        // Selected hour (0-23), minute (0-59)
-      }
-    } catch ({code, message}) {
-      console.warn('Cannot open time picker', message);
+  ```js
+  // Before
+  try {
+    const {action, hour, minute} = await TimePickerAndroid.open({
+      hour: 14,
+      minute: 0,
+      is24Hour: false, // Will display '2 PM'
+    });
+    if (action !== TimePickerAndroid.dismissedAction) {
+      // Selected hour (0-23), minute (0-59)
     }
-    ```
+  } catch ({code, message}) {
+    console.warn('Cannot open time picker', message);
+  }
+  ```
 
-    ```js
-    // Now
-    // It will use the hour and minute defined in date
-    <RNDateTimePicker mode="time" value={new Date()} />
-    ```
+  ```js
+  // Now
+  // It will use the hour and minute defined in date
+  <RNDateTimePicker mode="time" value={new Date()} />
+  ```
 
 - `timeSetAction` is deprecated, use `onChange` instead.
 
-    ```js
-    // Before
-    try {
-      const {action, hour, minute} = await TimePickerAndroid.open();
-      if (action === TimePickerAndroid.timeSetAction) {
-        // Selected hour (0-23), minute (0-59)
-      }
-    } catch ({code, message}) {
-      console.warn('Cannot open time picker', message);
+  ```js
+  // Before
+  try {
+    const {action, hour, minute} = await TimePickerAndroid.open();
+    if (action === TimePickerAndroid.timeSetAction) {
+      // Selected hour (0-23), minute (0-59)
     }
-    ```
+  } catch ({code, message}) {
+    console.warn('Cannot open time picker', message);
+  }
+  ```
 
-    ```js
-    // Now
-    setTime = (event, date) => {
-      if (date !== undefined) {
-        // Use the hour and minute from the date object
-      }
+  ```js
+  // Now
+  setTime = (event, date) => {
+    if (date !== undefined) {
+      // Use the hour and minute from the date object
     }
-    <RNDateTimePicker mode="time" onChange={this.setTime} />
-    ```
+  };
+  <RNDateTimePicker mode="time" onChange={this.setTime} />;
+  ```
 
 - `dismissedAction` is deprecated, use `onChange` instead.
 
-    ```js
-    // Before
-    try {
-      const {action, hour, minute} = await TimePickerAndroid.open();
-      if (action === TimePickerAndroid.dismissedAction) {
-        // Dismissed
-      }
-    } catch ({code, message}) {
-      console.warn('Cannot open time picker', message);
+  ```js
+  // Before
+  try {
+    const {action, hour, minute} = await TimePickerAndroid.open();
+    if (action === TimePickerAndroid.dismissedAction) {
+      // Dismissed
     }
-    ```
+  } catch ({code, message}) {
+    console.warn('Cannot open time picker', message);
+  }
+  ```
 
-    ```js
-    // Now
-    setTime = (event, date) => {
-      if (date === undefined) {
-        // dismissedAction
-      }
+  ```js
+  // Now
+  setTime = (event, date) => {
+    if (date === undefined) {
+      // dismissedAction
     }
-    <RNDateTimePicker mode="time" onChange={this.setTime} />
-    ```
+  };
+  <RNDateTimePicker mode="time" onChange={this.setTime} />;
+  ```
 
 ## Contributing to the component
 
@@ -491,40 +511,41 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md)
 2. Inside the iOS folder run `pod init`, this will create the initial `pod` file.
 3. Update your `pod` file to look like the following ( Remember to replace `MyApp` with your target name ):
 
-    ```ruby
-    # Allowed sources
-    source 'https://github.com/CocoaPods/Specs.git'
+   ```ruby
+   # Allowed sources
+   source 'https://github.com/CocoaPods/Specs.git'
 
-    target 'MyApp' do
-      # As we use Swift, ensure that `use_frameworks` is enabled.
-      use_frameworks!
+   target 'MyApp' do
+     # As we use Swift, ensure that `use_frameworks` is enabled.
+     use_frameworks!
 
-      # Specific iOS platform we are targetting
-      platform :ios, '8.0'
+     # Specific iOS platform we are targetting
+     platform :ios, '8.0'
 
-      # Point to the installed version
-      pod 'RNDateTimePicker', :path => '../node_modules/@react-native-community/datetimepicker/RNDateTimePicker.podspec'
+     # Point to the installed version
+     pod 'RNDateTimePicker', :path => '../node_modules/@react-native-community/datetimepicker/RNDateTimePicker.podspec'
 
-      # React/React-Native specific pods
-      pod 'React', :path => '../node_modules/react-native', :subspecs => [
-        'Core',
-        'CxxBridge',      # Include this for RN >= 0.47
-        'DevSupport',     # Include this to enable In-App Devmenu if RN >= 0.43
-        'RCTText',
-        'RCTNetwork',
-        'RCTWebSocket',   # Needed for debugging
-      ]
+     # React/React-Native specific pods
+     pod 'React', :path => '../node_modules/react-native', :subspecs => [
+       'Core',
+       'CxxBridge',      # Include this for RN >= 0.47
+       'DevSupport',     # Include this to enable In-App Devmenu if RN >= 0.43
+       'RCTText',
+       'RCTNetwork',
+       'RCTWebSocket',   # Needed for debugging
+     ]
 
-      # Explicitly include Yoga if you are using RN >= 0.42.0
-      pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+     # Explicitly include Yoga if you are using RN >= 0.42.0
+     pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
 
-      # Third party deps podspec link
-      pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-      pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-      pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
+     # Third party deps podspec link
+     pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
+     pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
+     pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
-    end
-    ```
+   end
+   ```
+
 4. Run `pod install` inside the same folder where the `pod` file was created
 5. `npm run start`
 6. `npm run start:ios`
@@ -532,12 +553,14 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md)
 #### Android
 
 1. Add the following lines to `android/settings.gradle`:
+
    ```gradle
    include ':@react-native-community_datetimepicker'
    project(':@react-native-community_datetimepicker').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/datetimepicker/android')
    ```
 
 2. Add the compile line to the dependencies in `android/app/build.gradle`:
+
    ```gradle
    dependencies {
        ...
@@ -546,6 +569,7 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md)
    ```
 
 3. Add the import and link the package in `MainApplication.java`:
+
    ```diff
    + import com.reactcommunity.rndatetimepicker.RNDateTimePickerPackage;
 
@@ -562,16 +586,15 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md)
    }
    ```
 
-
 ## Running the example app
 
 1. Install required pods in `example/ios` by running `pods install`
 1. Run `npm start` to start Metro Bundler
 1. Run `npm run start:ios` or `npm run start:android`
 
-[circle-ci-badge]:https://img.shields.io/circleci/project/github/react-native-community/react-native-datetimepicker/master.svg?style=flat-square
-[circle-ci-status]:https://circleci.com/gh/react-native-community/workflows/react-native-datetimepicker/tree/master
-[support-badge]:https://img.shields.io/badge/platforms-android%20|%20ios-lightgrey.svg?style=flat-square
-[license-badge]:https://img.shields.io/npm/l/@react-native-community/slider.svg?style=flat-square
+[circle-ci-badge]: https://img.shields.io/circleci/project/github/react-native-community/react-native-datetimepicker/master.svg?style=flat-square
+[circle-ci-status]: https://circleci.com/gh/react-native-community/workflows/react-native-datetimepicker/tree/master
+[support-badge]: https://img.shields.io/badge/platforms-android%20|%20ios-lightgrey.svg?style=flat-square
+[license-badge]: https://img.shields.io/npm/l/@react-native-community/slider.svg?style=flat-square
 [lean-core-badge]: https://img.shields.io/badge/Lean%20Core-Extracted-brightgreen.svg?style=flat-square
 [lean-core-issue]: https://github.com/facebook/react-native/issues/23313

--- a/README.md
+++ b/README.md
@@ -25,31 +25,31 @@ React Native date & time picker component for iOS and Android
 - [React Native DateTimePicker](#react-native-datetimepicker)
   - [Table of Contents](#table-of-contents)
   - [Getting started](#getting-started)
-      - [RN >= 0.60](#rn--060)
-      - [RN < 0.60](#rn--060-1)
+    - [RN >= 0.60](#rn--060)
+    - [RN < 0.60](#rn--060-1)
   - [General Usage](#general-usage)
     - [Basic usage with state](#basic-usage-with-state)
   - [Props](#props)
-      - [`mode` (`optional`)](#mode-optional)
-      - [`display` (`optional`, `Android only`)](#display-optional-android-only)
-      - [`onChange` (`optional`)](#onchange-optional)
-      - [`value` (`required`)](#value-required)
-      - [`maximumDate` (`optional`)](#maximumdate-optional)
-      - [`minimumDate` (`optional`)](#minimumdate-optional)
-      - [`timeZoneOffsetInMinutes` (`optional`, `iOS only`)](#timezoneoffsetinminutes-optional-ios-only)
-      - [`locale` (`optional`, `iOS only`)](#locale-optional-ios-only)
-      - [`is24Hour` (`optional`, `Android only`)](#is24hour-optional-android-only)
-      - [`neutralButtonLabel` (`optional`, `Android only`)](#neutralbuttonlabel-optional-android-only)
-      - [`minuteInterval` (`optional`, `iOS only`)](#minuteinterval-optional-ios-only)
-      - [`iOsPickerStyle` (`optional`, `iOS only`)](#iospickerstyle-optional-ios-only)
+    - [`mode` (`optional`)](#mode-optional)
+    - [`display` (`optional`, `Android only`)](#display-optional-android-only)
+    - [`onChange` (`optional`)](#onchange-optional)
+    - [`value` (`required`)](#value-required)
+    - [`maximumDate` (`optional`)](#maximumdate-optional)
+    - [`minimumDate` (`optional`)](#minimumdate-optional)
+    - [`timeZoneOffsetInMinutes` (`optional`, `iOS only`)](#timezoneoffsetinminutes-optional-ios-only)
+    - [`locale` (`optional`, `iOS only`)](#locale-optional-ios-only)
+    - [`is24Hour` (`optional`, `Android only`)](#is24hour-optional-android-only)
+    - [`neutralButtonLabel` (`optional`, `Android only`)](#neutralbuttonlabel-optional-android-only)
+    - [`minuteInterval` (`optional`, `iOS only`)](#minuteinterval-optional-ios-only)
+    - [`style` (`optional`, `iOS only`)](#style-optional-ios-only)
   - [Migration from the older components](#migration-from-the-older-components)
     - [DatePickerIOS](#datepickerios)
     - [DatePickerAndroid](#datepickerandroid)
     - [TimePickerAndroid](#timepickerandroid)
   - [Contributing to the component](#contributing-to-the-component)
   - [Manual installation](#manual-installation)
-      - [iOS](#ios)
-      - [Android](#android)
+    - [iOS](#ios)
+    - [Android](#android)
   - [Running the example app](#running-the-example-app)
 
 ## Getting started
@@ -265,13 +265,13 @@ Possible values are: `1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30`
 <RNDateTimePicker minuteInterval={10} />
 ```
 
-#### `iOsPickerStyle` (`optional`, `iOS only`)
+#### `style` (`optional`, `iOS only`)
 
-Sets style directly on picker component within internal container.
-By default height of picker is fixed to 216px regardless of what is set in style property.
+Sets style directly on picker component.
+By default height of picker is fixed to 216px.
 
 ```js
-<RNDateTimePicker iOsPickerStyle={{width: '100%', height: '100% '}} /> // will take up whole space defined in style property
+<RNDateTimePicker style={{flex: 1}} />
 ```
 
 ## Migration from the older components

--- a/example/App.js
+++ b/example/App.js
@@ -99,6 +99,7 @@ const App = () => {
                   is24Hour
                   display={display}
                   onChange={onChange}
+                  style={styles.iOsPicker}
                 />
               )}
             </View>
@@ -149,6 +150,9 @@ const styles = StyleSheet.create({
   dateTimeText: {
     fontSize: 16,
     fontWeight: 'normal',
+  },
+  iOsPicker: {
+    flex: 1,
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Martijn Swaagman <mswaagman@godaddy.com> (https://github.com/swaagie)",
   "contributors": [
     "Daniel Sanudo Vacas <dsanudovacas@godaddy.com> (https://github.com/DanielSanudo)",
-    "Vojtech Novak <vonovak@gmail.com> (https://github.com/vonovak)"
+    "Vojtech Novak <vonovak@gmail.com> (https://github.com/vonovak)",
     "Pavel Balint <lochness42@gmail.com> (https://github.com/lochness42)"
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/datetimepicker",
-  "version": "2.2.3",
+  "version": "2.2.2",
   "description": "DateTimePicker component for React Native",
   "main": "./src/index.js",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/datetimepicker",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "DateTimePicker component for React Native",
   "main": "./src/index.js",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "contributors": [
     "Daniel Sanudo Vacas <dsanudovacas@godaddy.com> (https://github.com/DanielSanudo)",
     "Vojtech Novak <vonovak@gmail.com> (https://github.com/vonovak)"
+    "Pavel Balint <lochness42@gmail.com> (https://github.com/lochness42)"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -69,7 +69,7 @@ export default class Picker extends React.Component<IOSNativeProps> {
       mode,
       minuteInterval,
       timeZoneOffsetInMinutes,
-      iOsPickerStyle,
+      iOsPickerStyle = {},
     } = this.props;
 
     invariant(value, 'A date or time should be specified as `value`.');
@@ -82,11 +82,7 @@ export default class Picker extends React.Component<IOSNativeProps> {
         <RNDateTimePicker
           testID={testID}
           ref={this._picker}
-          style={
-            iOsPickerStyle !== undefined && iOsPickerStyle !== null
-              ? iOsPickerStyle
-              : styles.picker
-          }
+          style={[styles.picker, iOsPickerStyle]}
           date={dates.value}
           locale={locale !== null && locale !== '' ? locale : undefined}
           maximumDate={dates.maximumDate}

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -82,7 +82,11 @@ export default class Picker extends React.Component<IOSNativeProps> {
         <RNDateTimePicker
           testID={testID}
           ref={this._picker}
-          style={iOsPickerStyle || styles.picker}
+          style={
+            iOsPickerStyle !== undefined && iOsPickerStyle !== null
+              ? iOsPickerStyle
+              : styles.picker
+          }
           date={dates.value}
           locale={locale !== null && locale !== '' ? locale : undefined}
           maximumDate={dates.maximumDate}

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -9,7 +9,7 @@
  * @format
  * @flow strict-local
  */
-import {View, StyleSheet} from 'react-native';
+import {StyleSheet} from 'react-native';
 import RNDateTimePicker from './picker';
 import {toMilliseconds} from './utils';
 import {MODE_DATE} from './constants';

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -69,6 +69,7 @@ export default class Picker extends React.Component<IOSNativeProps> {
       mode,
       minuteInterval,
       timeZoneOffsetInMinutes,
+      iOsPickerStyle,
     } = this.props;
 
     invariant(value, 'A date or time should be specified as `value`.');
@@ -81,7 +82,7 @@ export default class Picker extends React.Component<IOSNativeProps> {
         <RNDateTimePicker
           testID={testID}
           ref={this._picker}
-          style={styles.picker}
+          style={iOsPickerStyle || styles.picker}
           date={dates.value}
           locale={locale !== null && locale !== '' ? locale : undefined}
           maximumDate={dates.maximumDate}

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -69,7 +69,6 @@ export default class Picker extends React.Component<IOSNativeProps> {
       mode,
       minuteInterval,
       timeZoneOffsetInMinutes,
-      iOsPickerStyle = {},
     } = this.props;
 
     invariant(value, 'A date or time should be specified as `value`.');
@@ -78,23 +77,21 @@ export default class Picker extends React.Component<IOSNativeProps> {
     toMilliseconds(dates, 'value', 'minimumDate', 'maximumDate');
 
     return (
-      <View style={style}>
-        <RNDateTimePicker
-          testID={testID}
-          ref={this._picker}
-          style={[styles.picker, iOsPickerStyle]}
-          date={dates.value}
-          locale={locale !== null && locale !== '' ? locale : undefined}
-          maximumDate={dates.maximumDate}
-          minimumDate={dates.minimumDate}
-          mode={mode}
-          minuteInterval={minuteInterval}
-          timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
-          onChange={this._onChange}
-          onStartShouldSetResponder={() => true}
-          onResponderTerminationRequest={() => false}
-        />
-      </View>
+      <RNDateTimePicker
+        testID={testID}
+        ref={this._picker}
+        style={[styles.picker, style]}
+        date={dates.value}
+        locale={locale !== null && locale !== '' ? locale : undefined}
+        maximumDate={dates.maximumDate}
+        minimumDate={dates.minimumDate}
+        mode={mode}
+        minuteInterval={minuteInterval}
+        timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
+        onChange={this._onChange}
+        onStartShouldSetResponder={() => true}
+        onResponderTerminationRequest={() => false}
+      />
     );
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -6,7 +6,6 @@
 import type {SyntheticEvent} from 'CoreEventTypes';
 import type {NativeComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
-import type {ViewStyleProp} from 'StyleSheet';
 import type {ElementRef} from 'react';
 
 type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';

--- a/src/types.js
+++ b/src/types.js
@@ -104,7 +104,7 @@ export type IOSNativeProps = $ReadOnly<{|
   /**
    * Styles for internal picker component
    *
-   * By default picker has fixed height of 216 on iOS ignoring it's parent's container constraints
+   * By default, picker has fixed height of 216 on iOS, ignoring its parent's container constraints
    * This allows to override this and use things like flex in relation to it's internal parent container
    *
    */

--- a/src/types.js
+++ b/src/types.js
@@ -6,6 +6,7 @@
 import type {SyntheticEvent} from 'CoreEventTypes';
 import type {NativeComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
+import type {ViewStyleProp} from 'StyleSheet';
 import type {ElementRef} from 'react';
 
 type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
@@ -99,6 +100,15 @@ export type IOSNativeProps = $ReadOnly<{|
    * instance, to show times in Pacific Standard Time, pass -7 * 60.
    */
   timeZoneOffsetInMinutes?: ?number,
+
+  /**
+   * Styles for internal picker component
+   *
+   * By default picker has fixed height of 216 on iOS ignoring it's parent's container constraints
+   * This allows to override this and use things like flex in relation to it's internal parent container
+   *
+   */
+  iOsPickerStyle?: ?ViewStyleProp,
 |}>;
 
 export type AndroidNativeProps = $ReadOnly<{|

--- a/src/types.js
+++ b/src/types.js
@@ -100,15 +100,6 @@ export type IOSNativeProps = $ReadOnly<{|
    * instance, to show times in Pacific Standard Time, pass -7 * 60.
    */
   timeZoneOffsetInMinutes?: ?number,
-
-  /**
-   * Styles for internal picker component
-   *
-   * By default, picker has fixed height of 216 on iOS, ignoring its parent's container constraints
-   * This allows to override this and use things like flex in relation to it's internal parent container
-   *
-   */
-  iOsPickerStyle?: ?ViewStyleProp,
 |}>;
 
 export type AndroidNativeProps = $ReadOnly<{|

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,87 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DatePicker applies styling to \`View\` wrapper 1`] = `
-<View
+<RNDateTimePicker
+  date={1376949600000}
+  mode="date"
+  onChange={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
   style={
-    Object {
-      "backgroundColor": "red",
-    }
+    Array [
+      Object {
+        "height": 216,
+      },
+      Object {
+        "backgroundColor": "red",
+      },
+    ]
   }
->
-  <RNDateTimePicker
-    date={1376949600000}
-    mode="date"
-    onChange={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Array [
-        Object {
-          "height": 216,
-        },
-        Object {},
-      ]
-    }
-  />
-</View>
+/>
 `;
 
 exports[`DatePicker renders a native Component 1`] = `
-<View>
-  <RNDateTimePicker
-    date={1376949600000}
-    mode="date"
-    onChange={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Array [
-        Object {
-          "height": 216,
-        },
-        Object {},
-      ]
-    }
-  />
-</View>
+<RNDateTimePicker
+  date={1376949600000}
+  mode="date"
+  onChange={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "height": 216,
+      },
+      undefined,
+    ]
+  }
+/>
 `;
 
 exports[`DatePicker renders with mode \`datetime\` (iOS only) 1`] = `
-<View>
-  <RNDateTimePicker
-    date={1376949600000}
-    mode="datetime"
-    onChange={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Array [
-        Object {
-          "height": 216,
-        },
-        Object {},
-      ]
-    }
-  />
-</View>
+<RNDateTimePicker
+  date={1376949600000}
+  mode="datetime"
+  onChange={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "height": 216,
+      },
+      undefined,
+    ]
+  }
+/>
 `;
 
 exports[`DatePicker renders with mode \`time\` 1`] = `
-<View>
-  <RNDateTimePicker
-    date={1376949600000}
-    mode="time"
-    onChange={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      Array [
-        Object {
-          "height": 216,
-        },
-        Object {},
-      ]
-    }
-  />
-</View>
+<RNDateTimePicker
+  date={1376949600000}
+  mode="time"
+  onChange={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "height": 216,
+      },
+      undefined,
+    ]
+  }
+/>
 `;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -15,9 +15,12 @@ exports[`DatePicker applies styling to \`View\` wrapper 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "height": 216,
-      }
+      Array [
+        Object {
+          "height": 216,
+        },
+        Object {},
+      ]
     }
   />
 </View>
@@ -32,9 +35,12 @@ exports[`DatePicker renders a native Component 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "height": 216,
-      }
+      Array [
+        Object {
+          "height": 216,
+        },
+        Object {},
+      ]
     }
   />
 </View>
@@ -49,9 +55,12 @@ exports[`DatePicker renders with mode \`datetime\` (iOS only) 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "height": 216,
-      }
+      Array [
+        Object {
+          "height": 216,
+        },
+        Object {},
+      ]
     }
   />
 </View>
@@ -66,9 +75,12 @@ exports[`DatePicker renders with mode \`time\` 1`] = `
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
     style={
-      Object {
-        "height": 216,
-      }
+      Array [
+        Object {
+          "height": 216,
+        },
+        Object {},
+      ]
     }
   />
 </View>

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DatePicker applies styling to \`View\` wrapper 1`] = `
+exports[`DatePicker applies styling to DatePicker 1`] = `
 <RNDateTimePicker
   date={1376949600000}
   mode="date"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,10 +17,7 @@ describe('DatePicker', () => {
     const date = new Date(156e10);
     const tree = renderer.create(<DatePicker value={date} />).toJSON();
 
-    expect(tree).toHaveProperty(
-      ['children', 0, 'props', 'date'],
-      date.getTime(),
-    );
+    expect(tree).toHaveProperty('props.date', date.getTime());
   });
 
   it('calls onChange callback', () => {
@@ -74,10 +71,10 @@ describe('DatePicker', () => {
       .create(<DatePicker style={style} value={new Date(DATE)} />)
       .toJSON();
 
-    expect(tree).toHaveProperty(
-      'props.style.backgroundColor',
-      style.backgroundColor,
-    );
+    expect(tree).toHaveProperty('props.style', [
+      {height: 216},
+      {backgroundColor: 'red'},
+    ]);
     expect(tree).toMatchSnapshot();
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,7 +65,7 @@ describe('DatePicker', () => {
     expect(new DatePicker()._picker).toBeDefined();
   });
 
-  it('applies styling to `View` wrapper', () => {
+  it('applies styling to DatePicker', () => {
     const style = {backgroundColor: 'red'};
     const tree = renderer
       .create(<DatePicker style={style} value={new Date(DATE)} />)


### PR DESCRIPTION
# Summary

At the moment on iOS picker has fixed height of 216px, this PR exposes a new style property which is passed down to picker itself (style property is only propagated to internal View container and picker can overflow it)
If this style is not defined, we will fall back to height of 216px so it won't break existing apps.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     	|
| Android |    ❌     	|

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
