### PR TITLE
get repo ready to be renamed to datetimepicker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Development can be done using the example app. Follow readme instructions on run
 ### Clone, install
 
 ```sh
-git clone https://github.com/react-native-community/react-native-datetimepicker.git
-cd react-native-datetimepicker
+git clone https://github.com/react-native-community/datetimepicker.git
+cd datetimepicker
 npm install
 ```
 

--- a/RNDateTimePicker.podspec
+++ b/RNDateTimePicker.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = package['author']
   s.homepage     = package['homepage']
   s.platform     = :ios, "8.0"
-  s.source       = { :git => "https://github.com/react-native-community/react-native-datetimepicker", :tag => "v#{package['version']}" }
+  s.source       = { :git => "https://github.com/react-native-community/datetimepicker", :tag => "v#{s.version}" }
   s.source_files = "ios/*.{h,m}"
   s.requires_arc = true
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -186,7 +186,6 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation project(':react-native-datetimepicker')
 
     if (enableHermes) {
       def hermesPath = "../../node_modules/hermesvm/android/";

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -3,4 +3,4 @@ rootProject.name = 'example'
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle");
 applyNativeModulesSettingsGradle(settings, "../..")
 
-include ':app', ':react-native-datetimepicker'
+include ':app'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/react-native-community/react-native-datetimepicker.git"
+    "url": "git+https://github.com/react-native-community/datetimepicker.git"
   },
   "keywords": [
     "react-native-component",
@@ -46,9 +46,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/react-native-community/react-native-datetimepicker/issues"
+    "url": "https://github.com/react-native-community/datetimepicker/issues"
   },
-  "homepage": "https://github.com/react-native-community/react-native-datetimepicker#readme",
+  "homepage": "https://github.com/react-native-community/datetimepicker#readme",
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/runtime": "^7.5.5",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -2,7 +2,7 @@ const root = process.cwd();
 
 module.exports = {
   dependencies: {
-    'react-native-datetimepicker': {
+    datetimepicker: {
       root,
     },
   },


### PR DESCRIPTION


# Summary

I'd like to rename this repo from `react-native-community/react-native-datetimepicker` to just `react-native-community/datetimepicker` (many other repos follow this convention) and this PR contains some changes to get ready for it. Once it is approved, I'll merged and rename. Github will redirect old links to the new address.

## Test Plan

I just did some small changes to android code in example folder; I verified that it runs okay.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
